### PR TITLE
Add exclusion regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ The Grand Opinionated AutoTester (GOAT) automatically applies Seiso's standard t
 
 ## Getting Started
 1. Create a per-repository dictionary (relative to the root of your git repo).
-```bash
-mkdir -p .github/etc/
-touch .github/etc/dictionary.txt
-```
+    ```bash
+    mkdir -p .github/etc/
+    touch .github/etc/dictionary.txt
+    ```
 1. Ensure your code is checked out during the github action.
-```bash
-uses: actions/checkout@v2
-```
+    ```bash
+    uses: actions/checkout@v2
+    ```
 1. Add the goat to your GitHub Actions workflows.
-```bash
-uses: seisollc/goat@v0.4.0
-```
+    ```bash
+    uses: seisollc/goat@v0.4.0
+    ```
 
 ### Example
 To run the goat on each PR against `main`, create the following file as `.github/workflows/pr.yml`:
@@ -37,27 +37,39 @@ jobs:
 
 #### Customizations
 1. Populate the custom dictionary file in `.github/etc/dictionary.txt` for any repo-specific language.
-```bash
-$ cat << EOF >> .github/etc/dictionary.txt
-capricornis
-crispus
-EOF
-```
+    ```bash
+    $ cat << EOF >> .github/etc/dictionary.txt
+    capricornis
+    crispus
+    EOF
+    ```
 1. Configure the goat to skip terrascan scanning.
-```bash
-uses: seisollc/goat@v0.4.0
-with:
-  disable_terrascan: true
-```
+    ```bash
+    uses: seisollc/goat@v0.4.0
+    with:
+      disable_terrascan: true
+    ```
+1. Exclude a file extension.
+    ```bash
+    uses: seisollc/goat@v0.4.0
+    with:
+      exclude: \.md$
+    ```
+1. Exclude a list of files.
+    ```bash
+    uses: seisollc/goat@v0.4.0
+    with:
+      exclude: ^.*/(Dockerfile|Dockerfile\.dev)$
+    ```
 1. Provide a linting configuration for any of the linters `super-linter` uses.
-```bash
-$ mkdir -p .github/linters/
-$ cat << EOF >> .github/linters/.markdown-lint.yml
----
-MD013:
-  line_length: 120
-EOF
-```
+    ```bash
+    $ mkdir -p .github/linters/
+    $ cat << EOF >> .github/linters/.markdown-lint.yml
+    ---
+    MD013:
+      line_length: 120
+    EOF
+    ```
 
 ## GOAT Development
 ### Prerequisites

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Disable terrascan'
     required: false
     default: 'false'
+  exclude:
+    description: 'Exclude anything that matches the regular expression'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/tasks.py
+++ b/tasks.py
@@ -92,7 +92,7 @@ def run_security_tests(*, image: str):
 
     # Provide information about low priority vulnerabilities
     command = (
-        "--quiet image --exit-code 0 --severity "
+        "--quiet image --timeout 10m0s --exit-code 0 --severity "
         + ",".join(LOW_PRIORITY_VULNS)
         + " --format json --light --input "
         + working_dir
@@ -108,7 +108,7 @@ def run_security_tests(*, image: str):
 
     # Ensure no unacceptable vulnerabilities exist in the image
     command = (
-        "--quiet image --exit-code 1 --severity "
+        "--quiet image --timeout 10m0s --exit-code 1 --severity "
         + ",".join(UNACCEPTABLE_VULNS)
         + " --format json --light --input "
         + working_dir
@@ -161,9 +161,12 @@ def goat(c):  # pylint: disable=unused-argument
     LOG.info("Baaaaaaaaaaah! (Running the goat)")
     environment = {}
 
-    # Pass in all of the host environment variables starting with GITHUB_
+    # Pass in all of the host environment variables starting with GITHUB_ or
+    # INPUT_
     for element in dict(os.environ):
         if element.startswith("GITHUB_"):
+            environment[element] = os.environ.get(element)
+        if element.startswith("INPUT_"):
             environment[element] = os.environ.get(element)
 
     if os.environ.get("GITHUB_ACTIONS") == "true":


### PR DESCRIPTION
# Contributor Comments
Adds a method to exclude files from being checked based on a regex.  

## Testing
Replace `regex` with the regex you'd like to use in both examples below.  For more details, see the `README.md`.

### Local
When testing locally, don't forget to `git commit` any "testing" files (like an insecure `.tf` file, or `.md` file with typographical errors).
```bash
INPUT_EXCLUDE="regex" pipenv run invoke goat
```

### GitHub Actions
```bash
uses: seisollc/goat@v0.4.0
with:
  exclude: regex
```

## Pull Request Checklist
Thank you for submitting a contribution to `goat`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
- [ ] Rebase your branch against the latest commit of the target branch, which likely should be `main`
- [ ] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)
