### PR TITLE
Add invoke update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ LABEL org.opencontainers.image.licenses="MIT"
 WORKDIR /etc/opt/goat/
 ENV PIP_NO_CACHE_DIR=1
 COPY Pipfile Pipfile.lock ./
+# hadolint ignore=DL3016,DL3018
 RUN pipenv install --deploy --ignore-pipfile \
- && apk --no-cache add npm=14.16.0-r0 \
- && npm install --no-cache -g dockerfile_lint@0.3.4 \
-                              cspell@5.3.8 \
-                              markdown-link-check@3.8.6
+ && apk --no-cache add npm \
+ && npm install --no-cache -g dockerfile_lint \
+                              cspell \
+                              markdown-link-check
 
 WORKDIR /goat/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Based on python:alpine as of February 2021
-FROM github/super-linter:v3.15.2
+FROM github/super-linter:v3.15.3
 
 # Required for the github/super-linter log (cannot be disabled)
 RUN mkdir -p /tmp/lint/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Based on python:alpine as of February 2021
-FROM github/super-linter:v3.15.3
+FROM github/super-linter:v3.15.5
 
 # Required for the github/super-linter log (cannot be disabled)
 RUN mkdir -p /tmp/lint/

--- a/Pipfile
+++ b/Pipfile
@@ -10,3 +10,6 @@ docker = "*"
 gitpython = "*"
 invoke = "*"
 requests = "*"
+
+[requires]
+python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-gitpython = "*"
 docker = "*"
+gitpython = "*"
 invoke = "*"
+requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eadb3ec5c7d3409af1b2689cf149bc154303bbeb6d8e34c97a7eacd87792bc6a"
+            "sha256": "4566f1013cf1d5f5a3ba17998342736260ac16494ffb93d257a32a66256bd4b8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -32,11 +32,11 @@
         },
         "docker": {
             "hashes": [
-                "sha256:0604a74719d5d2de438753934b755bfcda6f62f49b8e4b30969a4b0a2a8a1220",
-                "sha256:e455fa49aabd4f22da9f4e1c1f9d16308286adc60abaf64bf3e1feafaed81d06"
+                "sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db",
+                "sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af"
             ],
             "index": "pypi",
-            "version": "==4.4.1"
+            "version": "==4.4.4"
         },
         "gitdb": {
             "hashes": [
@@ -48,11 +48,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:42dbefd8d9e2576c496ed0059f3103dcef7125b9ce16f9d5f9c834aed44a1dac",
-                "sha256:867ec3dfb126aac0f8296b19fb63b8c4a399f32b4b6fafe84c4b10af5fa9f7b5"
+                "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b",
+                "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"
             ],
             "index": "pypi",
-            "version": "==3.1.12"
+            "version": "==3.1.14"
         },
         "idna": {
             "hashes": [
@@ -76,7 +76,7 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "index": "pypi",
             "version": "==2.25.1"
         },
         "six": {
@@ -105,10 +105,11 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549",
-                "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"
+                "sha256:44b5df8f08c74c3d82d28100fdc81f4536809ce98a17f0757557813275fbb663",
+                "sha256:63509b41d158ae5b7f67eb4ad20fecbb4eee99434e73e140354dc3ff8e09716f"
             ],
-            "version": "==0.57.0"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.58.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,10 +1,12 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4566f1013cf1d5f5a3ba17998342736260ac16494ffb93d257a32a66256bd4b8"
+            "sha256": "d47f6f8e0a637720415b67885c1a4a23db7078789070510f6c9d86b70193b925"
         },
         "pipfile-spec": 6,
-        "requires": {},
+        "requires": {
+            "python_version": "3.9"
+        },
         "sources": [
             {
                 "name": "pypi",

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -42,11 +42,11 @@
         },
         "gitdb": {
             "hashes": [
-                "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac",
-                "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"
+                "sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0",
+                "sha256:96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==4.0.5"
+            "version": "==4.0.7"
         },
         "gitpython": {
             "hashes": [
@@ -91,11 +91,11 @@
         },
         "smmap": {
             "hashes": [
-                "sha256:7bfcf367828031dc893530a29cb35eb8c8f2d7c8f2d0989354d75d24c8573714",
-                "sha256:84c2751ef3072d4f6b2785ec7ee40244c6f45eb934d9e543e2c51f1bd3d54c50"
+                "sha256:7e65386bd122d45405ddf795637b7f7d2b532e7e401d46bbe3fb49b9986d5182",
+                "sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==3.0.5"
+            "markers": "python_version >= '3.5'",
+            "version": "==4.0.0"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -99,11 +99,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
-                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.3"
+            "version": "==1.26.4"
         },
         "websocket-client": {
             "hashes": [

--- a/tasks.py
+++ b/tasks.py
@@ -272,3 +272,18 @@ def update(c):  # pylint: disable=unused-argument
     for image in ["github/super-linter"]:
         version = get_latest_release_from_github(repo=image)
         update_dockerfile_from(image=image, tag=version)
+
+    # Update the CI dependencies
+    image = "python:3.9"
+    working_dir = "/usr/src/app/"
+    volumes = {CWD: {"bind": working_dir, "mode": "rw"}}
+    CLIENT.images.pull(repository=image)
+    command = '/bin/bash -c "python3 -m pip install --upgrade pipenv &>/dev/null && pipenv update"'
+    opinionated_docker_run(
+        image=image,
+        volumes=volumes,
+        working_dir=working_dir,
+        auto_remove=True,
+        detach=False,
+        command=command,
+    )


### PR DESCRIPTION
# Contributor Comments
Add `invoke update` (used via `pipenv run invoke update`) to maintain the project dependencies.

This reverts the version pinning of packages added in #23 due to maintenance concerns.

## Pull Request Checklist
Thank you for submitting a contribution to `goat`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:
- [X] Rebase your branch against the latest commit of the target branch, which likely should be `main`
- [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)