### PR TITLE
Move github action to use the latest image in docker hub

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,4 +12,4 @@ inputs:
     default: ''
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://hub.docker.com/seiso/goat:latest'


### PR DESCRIPTION
# Contributor Comments

Speed up the goat by running from docker hub's latest tag instead of building the image during each run.

## Pull Request Checklist

Thank you for submitting a contribution to `goat`!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch, which likely should be `main`
- [X] If there is an issue associated with your Pull Request, align your PR title with [this documentation](https://help.github.com/en/articles/closing-issues-using-keywords)