### PR TITLE
fix: github action update

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Publish the goat to Docker Hub
         run: pipenv run invoke publish
       - name: Delete the latest release on GitHub
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# Contributor Comments

It appears that one of the github actions we use (dev-drprasad/delete-tag-and-release) deleted their v0.2.0 tag and replaced it with v0.2.1.  Failure in https://github.com/SeisoLLC/goat/actions/runs/4480517067/jobs/7876187000#step:1:24

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
