### PR TITLE
chore: update super-linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Based on python:alpine as of February 2021
-FROM github/super-linter:slim-v4.10.1
+FROM github/super-linter:slim-v5.0.0
 
 # Required for the github/super-linter log (cannot be disabled)
 RUN mkdir -p /tmp/lint/


### PR DESCRIPTION
# Contributor Comments

This updates the super-linter and, as a side effect, will get a newer version of markdown-link-checker which fixes [this bug](https://github.com/tcort/markdown-link-check/pull/249) which we've been hitting.

## Manual Testing

To manually ensure the right version of markdown-link-check with the tcort/markdown-link-check#249 pulled in, run:

```bash
docker run -it --entrypoint /bin/bash github/super-linter:slim-v5.0.0
npm install --no-cache -g markdown-link-check && markdown-link-check --version
```

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
