### PR TITLE
fix: change ruff line length to 160

### DIFF
--- a/etc/pyproject.toml
+++ b/etc/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.ruff]
-# Allow lines to be as long as 120 characters.
-line-length = 120
+# Allow lines to be as long as 160 characters.
+line-length = 160


### PR DESCRIPTION
# Contributor Comments

This PR adjusts the line length enforced by ruff from 120 to 160.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [ ] If you are adding a dependency, please explain how it was chosen
- [ ] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [ ] If there is an issue associated with your Pull Request, link the issue to the PR.
