### PR TITLE
feat: ensure repo dictionaries are sorted

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,7 @@ function check_environment() {
 		mainline="${GITHUB_BASE_REF##*/}"
 		if [[ ${mainline} != "main" ]]; then
 			feedback ERROR "Base branch name is not main"
+			exit 1
 		fi
 	fi
 
@@ -80,6 +81,13 @@ function check_environment() {
 		feedback WARNING "The following words are already in the global dictionary:
 ${overlap}"
 		feedback ERROR "Overlap was detected in the per-repo and global dictionaries"
+		exit 1
+	fi
+
+	# Ensure dictionaries are sorted
+	if ! sort -c "${REPO_DICTIONARY}" 2>/dev/null; then
+		feedback ERROR "The repo dictionary must be sorted"
+		exit 1
 	fi
 }
 
@@ -171,7 +179,7 @@ function lint_files() {
 		fi
 
 		files_to_lint="$(get_files_matching_filetype "$type" "${linter_array[name]}" "${included[@]}")"
-		
+
 		if [ "${#files_to_lint}" -eq 0 ]; then
 			return
 		fi


### PR DESCRIPTION
# Contributor Comments

This has been an implicit requirement, but this makes it explicit.

This also fixes a minor bug introduced in 31d07bedee5dd5ac833974b3ae0eb1d2b0866402 where we expected ERROR feedbacks to exit non-zero, and when that was removed the existing checks in `check_environment` did not have an `exit 1` added.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
