### PR TITLE
fix: file exclusion regex not applied for linters marked "all"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,7 @@ function check_environment() {
 		mainline="${GITHUB_BASE_REF##*/}"
 		if [[ ${mainline} != "main" ]]; then
 			feedback ERROR "Base branch name is not main"
+			exit 1
 		fi
 	fi
 
@@ -80,6 +81,13 @@ function check_environment() {
 		feedback WARNING "The following words are already in the global dictionary:
 ${overlap}"
 		feedback ERROR "Overlap was detected in the per-repo and global dictionaries"
+		exit 1
+	fi
+
+	# Ensure dictionaries are sorted
+	if ! sort -c "${REPO_DICTIONARY}" 2>/dev/null; then
+		feedback ERROR "The repo dictionary must be sorted"
+		exit 1
 	fi
 }
 
@@ -171,7 +179,7 @@ function lint_files() {
 		fi
 
 		files_to_lint="$(get_files_matching_filetype "$type" "${linter_array[name]}" "${included[@]}")"
-		
+
 		if [ "${#files_to_lint}" -eq 0 ]; then
 			return
 		fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -165,7 +165,7 @@ function lint_files() {
 
 	for type in "${filetypes_to_lint[@]}"; do
 		if [[ $type == "all" ]]; then
-			cmd="${linter_array[name]} $linter_args"
+			cmd="${linter_array[name]} $linter_args ${included[@]}"
 			eval "$cmd" >>"${linter_array[logfile]}" 2>&1
 			return
 		fi
@@ -207,11 +207,11 @@ function seiso_lint() {
 	included=()
 
 	while read -r file; do
-		if [[ -n ${INPUT_EXCLUDE:+x} && "${file}" =~ ${INPUT_EXCLUDE} ]]; then
+		if [[ -n ${FILTER_REGEX_EXCLUDE:+x} && "${file}" =~ ${FILTER_REGEX_EXCLUDE} ]]; then
 			excluded+=("${file}")
 			continue
 		fi
-		included+=("$file")
+		included+=("${file}")
 	done < <(find . \( -path "./.git" -prune \) -o \( -type f -print \))
 
 	declare -A pids

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -173,7 +173,7 @@ function lint_files() {
 
 	for type in "${filetypes_to_lint[@]}"; do
 		if [[ $type == "all" ]]; then
-			cmd="${linter_array[name]} $linter_args ${included[@]}"
+			cmd="${linter_array[name]} $linter_args $(printf '%q ' "${included[@]}")"
 			eval "$cmd" >>"${linter_array[logfile]}" 2>&1
 			return
 		fi

--- a/etc/linters.json
+++ b/etc/linters.json
@@ -64,7 +64,7 @@
     },
     {
         "name": "jscpd",
-        "args": "--config /etc/opt/goat/.jscpd.json *",
+        "args": "--config /etc/opt/goat/.jscpd.json",
         "filetype": [
             "all"
         ],


### PR DESCRIPTION
# Contributor Comments

This PR fixes a bug in which linters in the linters.json file that were marked to check all filetypes were scanning all files in the directory instead of just those in the `included` array. 

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
