### PR TITLE
fix: pre-commit support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,10 +52,10 @@ function setup_environment() {
 		RELATIVE_PATH="${DEFAULT_WORKSPACE}"
 	elif [[ -n "${GITHUB_WORKSPACE:+x}" ]]; then
 		# GitHub Actions
-		RELATIVE_PATH="${DEFAULT_WORKSPACE}"
+		RELATIVE_PATH="${GITHUB_WORKSPACE}"
 	elif [[ -d "/src/.git" ]]; then
 		# Pre-commit
-		RELATIVE_PATH="${DEFAULT_WORKSPACE}"
+		RELATIVE_PATH="/src"
 	else
 		feedback ERROR "Unable to identify the right relative path to find the repo dictionary"
 		exit 1

--- a/file
+++ b/file
@@ -1,1 +1,0 @@
-example

--- a/file
+++ b/file
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
# Contributor Comments

There is an issue with using pre-commit in fdb0910452de991e5d48cfa313e153f1f6f65f81 because the goat `entrypoint.sh` could not accomodate the `/src` hard coded volume mounting from [here](https://github.com/pre-commit/pre-commit/blob/c25ea47cf78b42da8fd403c435f156b056aaeb38/pre_commit/languages/docker.py#L111-L121).

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch
- [X] If you are adding a dependency, please explain how it was chosen
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.