### PR TITLE
fix: move warning for env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -225,11 +225,11 @@ function lint_files() {
 
 	if [ "${CURRENT_LINT_ROUND}" -eq 2 ] && ! has_autofix "${linter_array[name]}"; then
 		linter_args="${linter_array[autofix]}"
-		feedback WARNING "The linter runtime for ${linter_array[name]} has been customized, which might have unwanted side effects. Use with caution."
 	fi
 
 	if [[ -v "${env_var_name}" ]]; then
 		linter_args="${!env_var_name}"
+		feedback WARNING "The linter runtime for ${linter_array[name]} has been customized, which might have unwanted side effects. Use with caution."
 	fi
 
 	for type in "${filetypes_to_lint[@]}"; do


### PR DESCRIPTION
# Contributor Comments

This fixes a placement error in the warning message generated when environment variables are used to replace linter command line arguments.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
