### PR TITLE
fix: add tk-dev for pyenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN pip install pipenv \
     tini \
     bash \
     git \
+    # The following apk package is necessary for pyenv functionality
+    tk-dev \
     && npm install --save-dev --no-cache -g dockerfile_lint \
     markdownlint-cli \
     textlint \
@@ -50,8 +52,8 @@ RUN pip install pipenv \
     jscpd \
     markdown-link-check \
     && git clone https://github.com/pyenv/pyenv.git --depth=1 "${PYENV_ROOT}" \
-    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile \
-    && echo 'eval "$(pyenv init -)"' >> ~/.profile \
+    && echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bash_profile \
     # This will cleanup the pyenv .git folder as well as any plugin .git folders
     && find "${PYENV_ROOT}" -type d -name ".git" -exec rm -rf {} + \
     && mkdir -p /opt/goat/log \
@@ -60,7 +62,7 @@ RUN pip install pipenv \
     && chmod o+w /opt/goat/log \
     && mkdir -p /.local \
     && chmod o+w /.local
-    #####################################################################################################
+#####################################################################################################
 
 WORKDIR /goat/
 


### PR DESCRIPTION
# Contributor Comments

An error was discovered that would prevent pipenv from creating a virtual environment due to pyenv not being able to complete installing the necessary version of Python. Pyenv's recommended dependencies are listed [here](https://github.com/pyenv/pyenv/wiki#suggested-build-environment). The minimum viable addition to the goat for full functionality is tk-dev, which was added to the Dockerfile.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
