### PR TITLE
fix: automaintain pre-commit releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/seisollc/goat
-    rev: c419a58c850d2009fbe453662fce7e5fb0ecdb1a  # frozen: latest
+    rev: 8fff94f14f2e4ca0e6ce33e569eb6d6d1bcf3fe0
     hooks:
       - id: seiso-lint


### PR DESCRIPTION
# Contributor Comments

automaintain pre-commit releases.  In 754b9ec5f2e08e199a4ff043ceb363ab27a0c019 I froze the pre-commit hash after a failed pipeline causing the hash in the repo to already be fully up to date, meaning that the `task pre-commit-update -- commit` in the pipeline had nothing to do, causing it to fail.  In order to fix this, we need to push an older pre-commit hash, so the update will have something to do.

Give those 🤖 some work!

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
