### PR TITLE
fix: don't pass filenames to pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,4 @@
   name: Lint (via the 🐐)
   language: system
   entry: task lint
+  pass_filenames: false


### PR DESCRIPTION
# Contributor Comments

Don't pass filenames to pre-commit (docs [here](https://pre-commit.com/#hooks-pass_filenames)); by default it will take your `entry` and pass the detected filenames to it. In our case, that detection happens inside of the `task` job (which `docker run`s the goat), so we need to turn that off.

If you hit this you'll get all kinds of strange issues like:

```bash
task: No tasks with description available. Try --list-all to list all tasks
task: Task ".pre-commit-config.yaml" does not exist
```

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
