### PR TITLE
refactor: move VERSION to the project Taskfile.yml

### DIFF
--- a/Task/bash/Taskfile.yml
+++ b/Task/bash/Taskfile.yml
@@ -13,10 +13,6 @@ includes:
     taskfile: ../Taskfile.yml
     internal: true
 
-vars:
-  VERSION:
-    sh: cat '{{.ROOT_DIR}}/VERSION'
-
 tasks:
   lint:
     desc: Run the linter(s); paved road projects use the Seiso goat 🐐
@@ -28,6 +24,7 @@ tasks:
           INPUT_DISABLE_MYPY: '{{.INPUT_DISABLE_MYPY | default ""}}'
           INPUT_EXCLUDE: '{{.INPUT_EXCLUDE | default ""}}'
           INPUT_LOG_LEVEL: '{{.INPUT_LOG_LEVEL | default ""}}'
+          VERSION: '{{.VERSION}}'
 
   build:
     desc: Build the project; docker images, compiled binaries, etc.

--- a/Task/python/Taskfile.yml
+++ b/Task/python/Taskfile.yml
@@ -25,6 +25,7 @@ tasks:
           INPUT_EXCLUDE: '{{.INPUT_EXCLUDE | default ""}}'
           INPUT_LOG_LEVEL: '{{.INPUT_LOG_LEVEL | default ""}}'
           IMAGE_NAME: '{{.IMAGE_NAME | default ""}}'
+          VERSION: '{{.VERSION}}'
 
   test:
     desc: Run the project tests

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,7 @@ includes:
       IMAGE_NAME: seiso/goat
       PROJECT_SLUG: goat
       PYTHON_VERSION: 3.11
+      VERSION: '{{.VERSION}}'
 
 vars:
   # This unfortunately needs to be duplicated, pending https://github.com/go-task/task/issues/1295
@@ -26,6 +27,8 @@ vars:
   INPUT_DISABLE_MYPY: true
   INPUT_EXCLUDE: '^/{{.PROJECT_SLUG}}/(goat|Task)/.*'
   SUPPORTED_PLATFORMS: 'linux/amd64,linux/arm64'
+  VERSION:
+    sh: cat '{{.ROOT_DIR}}/VERSION'
   LOCAL_PLATFORM:
     # Inspired by https://github.com/containerd/containerd/blob/e0912c068b131b33798ae45fd447a1624a6faf0a/platforms/database.go#L76
     sh: |


### PR DESCRIPTION
# Contributor Comments

After working with Taskfile vars more, it makes sense to move the VERSIOn variable to the project's `Taskfile.yml` instead of trying to make it transparent logic in the `goat` module. This gives more control and fixes unexpected behavior like https://github.com/go-task/task/issues/1295

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
