### PR TITLE
ci: implement docker driver workaround for task builds in a pipeline

### DIFF
--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
               build_version = f"{{.VERSION}}-{{.COMMIT_HASH_SHORT}}"
           print(build_version)'
     cmds:
+      - task: pipeline-docker-multiplatform-init
       # We only load when the provided platform equals the detected local platform. This is for two reasons:
       # 1. We assume you don't want to load a cross-platform build
       # 2. Currently (2023-07-30) you cannot --load if you are building multiple platforms


### PR DESCRIPTION
# Contributor Comments

This runs a workaround when someone is running a `task build` in a pipeline (on a github runner). This happens as a part of the paved road test suite.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
