### PR TITLE
ci: move docker driver workaround to language taskfiles

### DIFF
--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -93,7 +93,6 @@ tasks:
               build_version = f"{{.VERSION}}-{{.COMMIT_HASH_SHORT}}"
           print(build_version)'
     cmds:
-      - task: pipeline-docker-multiplatform-init
       # We only load when the provided platform equals the detected local platform. This is for two reasons:
       # 1. We assume you don't want to load a cross-platform build
       # 2. Currently (2023-07-30) you cannot --load if you are building multiple platforms

--- a/Task/bash/Taskfile.yml
+++ b/Task/bash/Taskfile.yml
@@ -32,6 +32,7 @@ tasks:
     requires:
       vars: ['VERSION']
     cmds:
+      - task: base:pipeline-docker-multiplatform-init
       - task: base:build
         vars:
           VERSION: '{{.VERSION}}'

--- a/Task/python/Taskfile.yml
+++ b/Task/python/Taskfile.yml
@@ -36,6 +36,7 @@ tasks:
     desc: Build the project; docker images, compiled binaries, etc.
     platforms: [linux, darwin]
     cmds:
+      - task: base:pipeline-docker-multiplatform-init
       - task: base:build
         vars:
           # Unable to make this global due to https://taskfile.dev/usage/#variables see https://github.com/go-task/task/issues/1295


### PR DESCRIPTION
# Contributor Comments

This moves the docker driver workaround to the `build` and `publish` language taskfiles due to https://github.com/SeisoLLC/goat/actions/runs/5787523946/job/15684788709#step:11:33

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
