### PR TITLE
feat: allow multiple builds in a single pipeline

### DIFF
--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -201,7 +201,8 @@ tasks:
       - '{{if eq .GITHUB_ACTIONS "true"}}exit 1{{end}}'
     cmds:
       # This fixes an "ERROR: Multiple platforms feature is currently not supported for docker driver" pipeline error
-      - docker buildx create --name multiplatform --driver docker-container --use
+      # Only create our multiplatform builder if it doesn't already exist; otherwise list information about the one that exists
+      - docker buildx inspect multiplatform || docker buildx create --name multiplatform --driver docker-container --use
 
   clean:
     desc: Clean up build artifacts, cache files/directories, temp files, etc.


### PR DESCRIPTION
# Contributor Comments

Historically we have only supported `PLATFORM=all task build` to build all images, or specifying a single platform to build at a time.  This adds support to do something like:

```bash
for platform in linux/arm64 linux/amd64; do
  PLATFORM=$platform task build
done
```

in a pipeline.  This is useful for testing builds individually or together.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
