### PR TITLE
fix: pre-commit yaml validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
     rev: af8ca5c6840ea54f062a0deb2ff8debec2afcb3f
     hooks:
       - id: seiso-lint
+sdfdfsd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,3 @@ repos:
     rev: af8ca5c6840ea54f062a0deb2ff8debec2afcb3f
     hooks:
       - id: seiso-lint
-sdfdfsd

--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -68,22 +68,18 @@ tasks:
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit config file"
-      - |
-        if test -f .pre-commit-config.yaml; 
-        then pipenv run pre-commit validate-config .pre-commit-config.yaml; 
-        else echo ".pre-commit-config.yaml does not exist"; 
-        fi
+      - pipenv run pre-commit validate-config .pre-commit-config.yaml; 
+    status:
+      - '! test -f .pre-commit-config.yaml'
 
   validate-pre-commit-manifest:
     desc: Validate the pre-commit hooks file
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit hooks file"
-      - |
-        if test -f .pre-commit-hooks.yaml;
-        then pipenv run pre-commit validate-manifest .pre-commit-hooks.yaml;
-        else echo ".pre-commit-hooks.yaml does not exist";
-        fi
+      - pipenv run pre-commit validate-manifest .pre-commit-hooks.yaml
+    status:
+      - '! test -f .pre-commit-hooks.yaml'
  
   build:
     desc: Build the project; docker images, compiled binaries, etc.

--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -68,16 +68,22 @@ tasks:
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit config file"
-      - cmd: pipenv run pre-commit validate-config .pre-commit-config.yaml
-        ignore_error: true
+      - |
+        if test -f .pre-commit-config.yaml; 
+        then pipenv run pre-commit validate-config .pre-commit-config.yaml; 
+        else echo ".pre-commit-config.yaml does not exist"; 
+        fi
 
   validate-pre-commit-manifest:
     desc: Validate the pre-commit hooks file
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit hooks file"
-      - cmd: pipenv run pre-commit validate-manifest .pre-commit-hooks.yaml
-        ignore_error: true
+      - |
+        if test -f .pre-commit-hooks.yaml;
+        then pipenv run pre-commit validate-manifest .pre-commit-hooks.yaml;
+        else echo ".pre-commit-hooks.yaml does not exist";
+        fi
  
   build:
     desc: Build the project; docker images, compiled binaries, etc.

--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit config file"
-      - pipenv run pre-commit validate-config .pre-commit-config.yaml; 
+      - pipenv run pre-commit validate-config .pre-commit-config.yaml
     status:
       - '! test -f .pre-commit-config.yaml'
 

--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -68,18 +68,16 @@ tasks:
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit config file"
-      - pipenv run pre-commit validate-config '.pre-commit-config.yaml'
-    status:
-      - test -f ../../.pre-commit-config.yaml
+      - cmd: pipenv run pre-commit validate-config .pre-commit-config.yaml
+        ignore_error: true
 
   validate-pre-commit-manifest:
     desc: Validate the pre-commit hooks file
     dir: ../../..
     cmds:
       - echo "-Validating pre-commit hooks file"
-      - pipenv run pre-commit validate-manifest '.pre-commit-hooks.yaml'
-    status:
-      - test -f ../../.pre-commit-hooks.yaml
+      - cmd: pipenv run pre-commit validate-manifest .pre-commit-hooks.yaml
+        ignore_error: true
  
   build:
     desc: Build the project; docker images, compiled binaries, etc.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,7 +62,7 @@ tasks:
       for its shared configs, etc.
     internal: true
     status:
-      # Don't update submodules if you aren't in a git repository; quote to avoid yaml intrepretering the ! as a node tag
+      # Only update submodules if you are in a git repository; quote to avoid yaml intrepretering the ! as a node tag
       # https://yaml.org/spec/1.2.2/#691-node-tags
       - '! test -d .git'
     cmds:
@@ -74,7 +74,7 @@ tasks:
     sources:
       - .pre-commit-config.yaml
     status:
-      # Don't install the pre-commit hooks if you aren't in a git repository; quote to avoid yaml intrepretering the ! as a node tag
+      # Only install the pre-commit hooks if you are in a git repository; quote to avoid yaml intrepretering the ! as a node tag
       # https://yaml.org/spec/1.2.2/#691-node-tags
       - '! test -d .git'
     cmds:


### PR DESCRIPTION
# Contributor Comments

This PR fixes a bug introduced by the pre-commit validation. If a .pre-commit-*.yaml file doesn't exist, the goat would exit. This was fixed by adding an if statement to the validation bash command.

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
