### PR TITLE
ci: reorder release process

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -104,6 +104,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: seiso/goat
           short-description: Seiso's Grand Opinionated AutoTester (GOAT)
+      - name: Push the release commit
+        run: |
+          BRANCH="$(git branch --show-current)"
+          git push --atomic origin "${BRANCH}" "${{ env.TAG }}"
       - name: Publish the release to GitHub
         uses: softprops/action-gh-release@v1
         env:
@@ -113,7 +117,3 @@ jobs:
           tag_name: ${{ env.TAG }}
           draft: false
           prerelease: false
-      - name: Push the release commit
-        run: |
-          BRANCH="$(git branch --show-current)"
-          git push --atomic origin "${BRANCH}" "${{ env.TAG }}"


### PR DESCRIPTION
# Contributor Comments

Reorder release processes; this [failed before](https://github.com/SeisoLLC/goat/actions/runs/5812622750/job/15758661200#step:14:15) because `softprops/action-gh-release` pushes the tag as a part of creating the release.  I manually deleted the `v2023.08.15` tag with the below command and deleted the `v2023.08.15` and `latest` releases on the repo as well.

```bash
$ git push --delete origin v2023.08.15
To github.com:SeisoLLC/goat.git
 - [deleted]         v2023.08.15
```

## Pull Request Checklist

Thank you for submitting a contribution to the goat!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch
- [x] If you are adding a dependency, please explain how it was chosen
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
