### PR TITLE
fix(sbom): support required docker buildx customization

### DIFF
--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -170,6 +170,7 @@ tasks:
       OUTPUT_FILE: '{{.IMAGE_NAME | replace "/" "_"}}_{{.BUILD_VERSION}}_{{.PLATFORM | replace "/" "_" | replace "," "_"}}.tar'
       DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
       DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT | default "."}}'
+      DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
     cmds:
       # We only load when the provided platform equals the detected local platform. This is for two reasons:
       # 1. We assume you don't want to load a cross-platform build
@@ -255,6 +256,7 @@ tasks:
           VERSION: '{{.VERSION}}'
           PLATFORM: '{{.PLATFORM | default .LOCAL_PLATFORM}}'
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
           DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
 
   update:
@@ -349,6 +351,8 @@ tasks:
           # This is necessary in order to have a separate tag per platform, and ensure there is only one manifest in the image index due to current
           # syft/stereoscope limitations
           DOCKER_BUILDX_CUSTOM_TAGS: '--tag {{.IMAGE_AND_TAG}}-{{.platform | replace "/" "_"}}'
+          DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
       - for:
           var: PLATFORM
           split: ','

--- a/Task/bash/Taskfile.yml
+++ b/Task/bash/Taskfile.yml
@@ -43,6 +43,8 @@ tasks:
           VERSION: '{{.VERSION}}'
           PLATFORM: '{{.PLATFORM}}'
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   update:
     desc: >
@@ -68,6 +70,7 @@ tasks:
           PLATFORM: '{{.PLATFORM}}'
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
           DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   clean:
     desc: Clean up build artifacts, cache files/directories, temp files, etc.
@@ -78,6 +81,10 @@ tasks:
     desc: Generate project SBOMs
     cmds:
       - task: base:sbom
+        vars:
+          DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   vulnscan:
     desc: Vuln scan the SBOM

--- a/Task/python/Taskfile.yml
+++ b/Task/python/Taskfile.yml
@@ -86,6 +86,8 @@ tasks:
     desc: Generate project SBOMs
     cmds:
       - task: base:sbom
+        vars:
+          DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
 
   vulnscan:
     desc: Vuln scan the SBOM

--- a/Task/python/Taskfile.yml
+++ b/Task/python/Taskfile.yml
@@ -49,6 +49,8 @@ tasks:
             sh: pipenv run python -c 'from {{.PROJECT_SLUG}} import __version__; print(__version__)'
           PLATFORM: '{{.PLATFORM}}'
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   update:
     desc: >
@@ -74,6 +76,7 @@ tasks:
           PLATFORM: '{{.PLATFORM}}'
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
           DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   clean:
     desc: Clean up build artifacts, cache files/directories, temp files, etc.
@@ -88,6 +91,8 @@ tasks:
       - task: base:sbom
         vars:
           DOCKER_BUILDX_CUSTOM_ARGS: '{{.DOCKER_BUILDX_CUSTOM_ARGS | default ""}}'
+          DOCKER_BUILDX_CUSTOM_CONTEXT: '{{.DOCKER_BUILDX_CUSTOM_CONTEXT}}'
+          DOCKER_BUILDX_CUSTOM_TAGS: '{{.DOCKER_BUILDX_CUSTOM_TAGS | default ""}}'
 
   vulnscan:
     desc: Vuln scan the SBOM


### PR DESCRIPTION
# Contributor Comments

This fixes an issue where, if your build requires custom docker buildx inputs (like build args), you could not previously generate a sbom.  By passing that context through the sbom task as well, it now works.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: https://www.wrike.com/open.htm?id=1193580816
-->