### PR TITLE
fix: runner apt install permissions

### DIFF
--- a/Task/Taskfile.yml
+++ b/Task/Taskfile.yml
@@ -52,7 +52,7 @@ tasks:
           var: TOOLS
           split: ','
           as: tool
-        cmd: apt-get install -y --no-install-recommends {{.tool}}
+        cmd: sudo apt-get install -y --no-install-recommends {{.tool}}
 
   runner-curl-install:
     desc: Install something on a GitHub Actions runner via curl


### PR DESCRIPTION
# Contributor Comments

This fixes our runner-apt-install base task; to install via `apt-get` in a github action you must run with `sudo`.

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [x] Rebase your branch against the latest commit of the target branch.
- [x] If you are adding a dependency, please explain how it was chosen.
- [x] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [x] If there is an issue associated with your Pull Request, link the issue to the PR.
- [x] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).

<!-- 
Wrike: https://www.wrike.com/open.htm?id=1268760516
-->