### PR TITLE
fix: cspell error when run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ jobs:
 - textlint
 - yamllint
 
+#### Supported Pipelines
+
+- GitHub Actions
+- Bitbucket Pipelines
+
 #### Debugging
 
 To debug an issue with the goat, configure the log level to either `ERROR`, `WARN`, `INFO`, or `DEBUG`.

--- a/etc/cspell.config.js
+++ b/etc/cspell.config.js
@@ -1,5 +1,16 @@
 'use strict'
 
+let per_repo_dictionary_file;
+
+if (process.env.GITHUB_WORKSPACE) {
+  per_repo_dictionary_file = `${process.env.GITHUB_WORKSPACE}/.github/etc/dictionary.txt`;
+} else if (process.env.BITBUCKET_CLONE_DIR) {
+  per_repo_dictionary_file = `${process.env.BITBUCKET_CLONE_DIR}/dictionary.txt`;
+} else {
+  /** Assume it's running local and use .github **/
+  per_repo_dictionary_file = '/goat/.github/etc/dictionary.txt';
+}
+
 /** @type { import("@cspell/cspell-types").CSpellUserSettings } */
 const cspell = {
   language: 'en',
@@ -28,7 +39,7 @@ const cspell = {
   dictionaryDefinitions: [
     {
       name: 'per-repository dictionary',
-      path: `${process.env.GITHUB_WORKSPACE ? process.env.GITHUB_WORKSPACE : '.'}/.github/etc/dictionary.txt`
+      path: per_repo_dictionary_file,
     },
     {
       name: 'seiso global dictionary',


### PR DESCRIPTION
# Contributor Comments

When run locally, the file location of `dictionary.txt` wasn't probably accounted for in the cspell config file.

I tested this locally on `easy_infra` (GitHub) and my [bitbucket pipeline demo project](https://bitbucket.org/jonzeolla/demo).

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch.
- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).