### PR TITLE
fix: running the goat locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1
 
-# TARGETPLATFORM is special cased by docker and doesn't need the inital ARG
+# TARGETPLATFORM is special cased by docker and doesn't need the initial ARG
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
-FROM --platform=$TARGETPLATFORM ghcr.io/yannh/kubeconform:v0.6.3 as kubeconform
+FROM --platform=$TARGETPLATFORM ghcr.io/yannh/kubeconform:v0.6.6-alpine as kubeconform
 ARG TARGETPLATFORM
 FROM --platform=$TARGETPLATFORM hadolint/hadolint:v2.12.0-alpine as hadolint
 ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM koalaman/shellcheck:v0.9.0 as shellcheck
+FROM --platform=$TARGETPLATFORM koalaman/shellcheck:v0.10.0 as shellcheck
 ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM rhysd/actionlint:1.6.25 as actionlint
+FROM --platform=$TARGETPLATFORM rhysd/actionlint:1.7.1 as actionlint
 
 ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM python:3.11-alpine3.18 as base_image
+FROM --platform=$TARGETPLATFORM python:3.11-alpine3.20 as base_image
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -163,6 +163,7 @@ tasks:
     desc: Clean up build artifacts, cache files/directories, temp files, etc.
     cmds:
       - task: bash:clean
+      - rm -rf {{.ROOT_DIR}}/node_modules
 
   release:
     desc: Cut a project release

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -455,7 +455,7 @@ function rerun_lint() {
 }
 
 function initiate_code_review() {
-  if [ -n "$GITHUB_ACTIONS" ]; then
+  if [[ -n ${GITHUB_ACTIONS:+x} ]]; then
     # Run the Python script
     python /opt/goat/bin/code_review.py
   fi


### PR DESCRIPTION
# Contributor Comments

This fixes a regression from e40e851a4f8925606824d6a6b0b10a9f378ac3ff where it checks for a github action-only variable in a way that fails the overall workload.

## Manual testing

Tested it locally with a `task build` and `task lint` which now works but when testing I had to temporarily remove the following otherwise it would pull from docker hub and overwrite the local build

https://github.com/SeisoLLC/goat/blob/f5005e6636726c17fb3a0c572fd7a608d4c74a80/Task/Taskfile.yml#L99-L102

## Pull Request Checklist

Thank you for submitting a contribution to our project!

In order to streamline the review of your contribution we ask that you review and comply with the below requirements:

- [X] Rebase your branch against the latest commit of the target branch.
- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.

Don't forget our more detailed contribution guidelines
[here](https://github.com/SeisoLLC/operations/blob/main/documents/software-guidelines.md#contributing-to-a-repository).